### PR TITLE
feat(R): calculate both SE on BNF run

### DIFF
--- a/server/BN_filter_R/bnf_fcns.R
+++ b/server/BN_filter_R/bnf_fcns.R
@@ -1043,7 +1043,7 @@ bnf <- function(y,
   
   is_idm <- iterative > 0 && demean == "dm"
   
-  tmp <-
+  bnf_result <-
     BN_Filter(demeaned_dy,
               p,
               delta,
@@ -1053,7 +1053,7 @@ bnf <- function(y,
               outliers,
               adjusted_bands)
   
-  cycle <- tmp$BN_cycle
+  cycle <- bnf_result$BN_cycle
   
   DeltaBNcycle <- diff(x = cycle, lag = 1)
   
@@ -1076,7 +1076,7 @@ bnf <- function(y,
         delta <- fixed_delta
       }
       
-      tmp <-
+      bnf_result <-
         BN_Filter(demeaned_dy,
                   p,
                   delta,
@@ -1086,7 +1086,7 @@ bnf <- function(y,
                   outliers,
                   adjusted_bands)
       
-      cycle <- tmp$BN_cycle
+      cycle <- bnf_result$BN_cycle
       DeltaBNcycle <- diff(x = cycle, lag = 1)
       
       cycle_iter <- cbind(cycle_iter, cycle)
@@ -1096,14 +1096,14 @@ bnf <- function(y,
     
   }
   
-  tmp <- BN_Filter_stderr(demeaned_dy,
-                          p,
-                          dynamic_bands,
-                          ib,
-                          window,
-                          outliers,
-                          adjusted_bands,
-                          bnf_result = tmp)
+  bnf_result <- BN_Filter_stderr(demeaned_dy,
+                                 p,
+                                 dynamic_bands,
+                                 ib,
+                                 window,
+                                 outliers,
+                                 adjusted_bands,
+                                 bnf_result)
   
   colnames(cycle) <- "Cycle"
   
@@ -1123,16 +1123,16 @@ bnf <- function(y,
   result$y <- y
   result$cycle <- cycle
   result$trend <- y - cycle
-  result$cycle_se <- tmp$BN_cycle_se
+  result$cycle_se <- bnf_result$BN_cycle_se
   result$delta <- delta
   result$demean_method <- demean_method
   result$iterative <- iterative
   result$cycle_ci <-
-    round(qnorm(p = 0.05 / 2.0, lower.tail = FALSE), 2) * tmp$BN_cycle_se
+    round(qnorm(p = 0.05 / 2.0, lower.tail = FALSE), 2) * bnf_result$BN_cycle_se
   if (adjusted_bands) {
-    result$cycle_adjusted_se <- tmp$BN_cycle_adjusted_se
+    result$cycle_adjusted_se <- bnf_result$BN_cycle_adjusted_se
     result$cycle_ci_adjusted <-
-      round(qnorm(p = 0.05 / 2.0, lower.tail = FALSE), 2) * tmp$BN_cycle_adjusted_se
+      round(qnorm(p = 0.05 / 2.0, lower.tail = FALSE), 2) * bnf_result$BN_cycle_adjusted_se
   }
   if (iterative > 0) {
     result$iterations <- ncol(cycle_iter) - 1

--- a/server/BN_filter_R/bnf_fcns.R
+++ b/server/BN_filter_R/bnf_fcns.R
@@ -1153,7 +1153,8 @@ print.bnfClass <-
 plot.bnfClass <- function(x,
                           main = "BN Filter Cycle",
                           plot_ci = TRUE,
-                          col = "blue",
+                          col = "red",
+                          secondary_col = "blue",
                           lwd = 2,
                           ...)
 {
@@ -1241,6 +1242,18 @@ plot.bnfClass <- function(x,
       col = adjustcolor(col, alpha.f = 0.2),
       border = NA
     )
+    
+    if("cycle_ci_adjusted" %in% names(x)) {
+      polygon(
+        x = c(x_axis, rev(x_axis)),
+        y = c((x$cycle - x$cycle_ci_adjusted),
+              rev(x$cycle + x$cycle_ci_adjusted)
+        ),
+        col = adjustcolor(secondary_col, alpha.f = 0.1),
+        border = NA
+      )
+    }
+
   }
   
   # Mark the LHS y-axis

--- a/server/BN_filter_R/bnf_fcns.R
+++ b/server/BN_filter_R/bnf_fcns.R
@@ -1041,7 +1041,7 @@ bnf <- function(y,
     delta <- fixed_delta
   }
   
-  is_idm <- iterative > 0 && demean == "dm"
+  
   
   bnf_result <-
     BN_Filter(demeaned_dy,
@@ -1057,6 +1057,7 @@ bnf <- function(y,
   
   DeltaBNcycle <- diff(x = cycle, lag = 1)
   
+  is_idm <- iterative > 0 && demean == "dm"
   if (is_idm) {
     cycle_iter <- cbind(zeros(nrow(cycle), 1), cycle)
     iter <- 1

--- a/server/BN_filter_R/bnf_fcns.R
+++ b/server/BN_filter_R/bnf_fcns.R
@@ -885,15 +885,17 @@ BN_Filter_stderr <-
     BN_cycle_se <- matrix(data = NA_real_,
                           nrow = tobs,
                           ncol = 1)
-    
+  
+    # Calculate both sets of std err.
     if (adjusted_bands) {
       BN_cycle_se_adjusted <- BN_cycle_se
+      
       bnf_result$BN_cycle_adjusted_se <-
-        compute_bn_cycle_se(BN_cycle_se_adjusted, TRUE)
+        compute_bn_cycle_se(BN_cycle_se_adjusted, adjusted_bands = TRUE)
     }
     
     bnf_result$BN_cycle_se <-
-      compute_bn_cycle_se(BN_cycle_se, FALSE)
+      compute_bn_cycle_se(BN_cycle_se, adjusted_bands = FALSE)
     
     
     return (bnf_result)

--- a/server/BN_filter_R/bnf_fcns.R
+++ b/server/BN_filter_R/bnf_fcns.R
@@ -621,7 +621,6 @@ backcast <- function(y, p, delta) {
 #
 # OUTPUTS:
 # BN_cycle    The estimated cycle
-# BN_cycle_se The estimated cycle standard error
 # aux_out     Auxiliary output (AR coefficients & residuals )
 BN_Filter <-
   function(y,
@@ -744,6 +743,7 @@ BN_Filter <-
     return (result)
   }
 
+# Calculates the standard error of the BNF. Must use result from `BN_filter`
 BN_Filter_stderr <-
   function(y,
            p,
@@ -1040,8 +1040,6 @@ bnf <- function(y,
   else {
     delta <- fixed_delta
   }
-  
-  
   
   bnf_result <-
     BN_Filter(demeaned_dy,

--- a/server/BN_filter_R/bnf_fcns.R
+++ b/server/BN_filter_R/bnf_fcns.R
@@ -626,12 +626,7 @@ BN_Filter <-
   function(y,
            p,
            delta,
-           dynamic_bands,
-           ib,
-           window,
-           outliers,
-           adjusted_bands,
-           compute_stderr = TRUE)
+           ib)
   {
     # Do a few preliminary things
     y <- as.matrix(y)
@@ -929,7 +924,7 @@ select_delta <- function(y, p, ib, delta_select, d0, dt)
   # Initialise the amplitude to noise ratio
   delta_grid <- d0
   tmp <-
-    BN_Filter(y, p, delta_grid, dynamic_bands, ib, window, outliers, F)
+    BN_Filter(y, p, delta_grid, ib)
   old_amp_to_noise <-
     var(tmp$BN_cycle) / mean(square(tmp$aux_out$residuals))
   old_precisionDeltaBNtrend <- tmp$aux_out$varDeltaBNtrend
@@ -937,7 +932,7 @@ select_delta <- function(y, p, ib, delta_select, d0, dt)
   while (diff_t > 0) {
     delta_grid <- delta_grid + dt
     tmp <-
-      BN_Filter(y, p, delta_grid, dynamic_bands, ib, window, outliers, F)
+      BN_Filter(y, p, delta_grid, ib)
     new_amp_to_noise <-
       var(tmp$BN_cycle) / mean(square(tmp$aux_out$residuals))
     new_precisionDeltaBNtrend <- tmp$aux_out$varDeltaBNtrend
@@ -1047,11 +1042,7 @@ bnf <- function(y,
     BN_Filter(demeaned_dy,
               p,
               delta,
-              dynamic_bands,
-              ib,
-              window,
-              outliers,
-              adjusted_bands)
+              ib)
   
   cycle <- bnf_result$BN_cycle
   
@@ -1081,11 +1072,7 @@ bnf <- function(y,
         BN_Filter(demeaned_dy,
                   p,
                   delta,
-                  dynamic_bands,
-                  ib,
-                  window,
-                  outliers,
-                  adjusted_bands)
+                  ib)
       
       cycle <- bnf_result$BN_cycle
       DeltaBNcycle <- diff(x = cycle, lag = 1)

--- a/server/BN_filter_R/bnf_fcns.R
+++ b/server/BN_filter_R/bnf_fcns.R
@@ -10,7 +10,7 @@
 # MATLAB codes converted to R by Luke Hartigan, 2017
 # Additional R codes and wrapper class 'bnf' written by Luke Hartigan, 2017
 # Updated by James Morley, 2022
-# Additional code changes by Cristian, 2022/2023/2024
+# Additional code changes by Cristian, 2022/2023/2024/2025
 ####################################################################################################
 
 # Helper functions used by the main functions below

--- a/server/BN_filter_R/bnf_fcns.R
+++ b/server/BN_filter_R/bnf_fcns.R
@@ -1013,7 +1013,6 @@ bnf <- function(y,
   }
   
   
-  
   # Automatically compute delta to pass to BN_Filter
   if (delta_select > 0) {
     delta <- select_delta(demeaned_dy, p, ib, delta_select, d0, dt)
@@ -1021,6 +1020,9 @@ bnf <- function(y,
   else {
     delta <- fixed_delta
   }
+  
+  is_idm <- iterative > 0 && demean == "dm"
+  
   tmp <-
     BN_Filter(demeaned_dy,
               p,
@@ -1029,15 +1031,16 @@ bnf <- function(y,
               ib,
               window,
               outliers,
-              adjusted_bands)
-  # TODO: check: SE may only need to calculated if `!(iterative > 0 && demean == "dm")`
+              adjusted_bands,!is_idm)  # TODO: check this optimisation
+  
   cycle <- tmp$BN_cycle
   
   DeltaBNcycle <- diff(x = cycle, lag = 1)
   
-  if (iterative > 0 && demean == "dm") {
+  if (is_idm) {
     cycle_iter <- cbind(zeros(nrow(cycle), 1), cycle)
     iter <- 1
+    
     while (iter < iterative &&
            sd(cycle_iter[, ncol(cycle_iter)] - cycle_iter[, ncol(cycle_iter) - 1]) >
            0.001 * sd(demeaned_dy)) {
@@ -1068,7 +1071,7 @@ bnf <- function(y,
       
       cycle_iter <- cbind(cycle_iter, cycle)
       
-      iter = iter + 1
+      iter <- iter + 1
     }
   }
   

--- a/server/BN_filter_R/bnf_run.R
+++ b/server/BN_filter_R/bnf_run.R
@@ -41,7 +41,8 @@ bnfOutput <- bnf(
   demean = "dm",
   iterative = 100,
   dynamic_bands = T,
-  adjust_bands = T,
+  adjusted_bands = T,
+  unadjusted_bands = T,
   outliers = c(293, 294),
   window = 40,
   ib = T

--- a/server/BN_filter_R/bnf_run.R
+++ b/server/BN_filter_R/bnf_run.R
@@ -58,7 +58,12 @@ bnfOutput <- bnf(
 
 
 write.csv(bnfOutput$cycle, "us_cycle_R_bnf.csv")
-plot(bnfOutput, main = "US Output Gap", col = "red")
+plot(
+  bnfOutput,
+  main = "US Output Gap",
+  col = "red",
+  secondary_col = "blue"
+)
 cat("\nPrinting out cycle data...\n")
 print(bnfOutput) # comment this command to stop the cycle data being printed to the console
 cat('\n')

--- a/server/BN_filter_R/bnf_run.R
+++ b/server/BN_filter_R/bnf_run.R
@@ -42,7 +42,6 @@ bnfOutput <- bnf(
   iterative = 100,
   dynamic_bands = T,
   adjusted_bands = T,
-  unadjusted_bands = T,
   outliers = c(293, 294),
   window = 40,
   ib = T

--- a/server/python_to_r_interface/Bnf.py
+++ b/server/python_to_r_interface/Bnf.py
@@ -27,8 +27,8 @@ class BNF:
         else:
             self.iterative = 0
 
-        self.adjust_bands = bool(outliers_for_se)
-        self.outliers_for_se = create_int_array(outliers_for_se if self.adjust_bands else [])
+        self.return_adjusted_bands = bool(outliers_for_se)
+        self.outliers_for_se = create_int_array(outliers_for_se if self.return_adjusted_bands else [])
         self.dynamic_bands = self.iterative != 0
 
         # outputs (of interest)
@@ -42,7 +42,7 @@ class BNF:
                                             fixed_delta=self.delta,
                                             d0=self.d0,
                                             demean=self.demean,
-                                            adjusted_bands=self.adjust_bands,
+                                            adjusted_bands=self.return_adjusted_bands,
                                             outliers=self.outliers_for_se,
                                             dynamic_bands=self.dynamic_bands,
                                             ib=self.ib,
@@ -51,7 +51,7 @@ class BNF:
         self.trend = [convert_to_float(v) for v in bnf_output.rx2('trend')]
         self.cycle = [convert_to_float(v) for v in bnf_output.rx2('cycle')]
         self.cycle_ci = [convert_to_float(v) for v in bnf_output.rx2('cycle_ci')]
-        if self.adjust_bands:
+        if self.return_adjusted_bands:
             self.cycle_ci_adjusted = [convert_to_float(v) for v in bnf_output.rx2('cycle_ci_adjusted')]
         self.delta = convert_to_float(bnf_output.rx2('delta')[0])
 
@@ -64,6 +64,6 @@ class BNF:
             "trend": self.trend,
             "cycle": self.cycle,
             "cycle_ci": self.cycle_ci,
-            **({"cycle_ci_adjusted": self.cycle_ci_adjusted} if self.adjust_bands else {}),
+            **({"cycle_ci_adjusted": self.cycle_ci_adjusted} if self.return_adjusted_bands else {}),
             "delta": self.delta
         }

--- a/server/python_to_r_interface/Bnf.py
+++ b/server/python_to_r_interface/Bnf.py
@@ -42,7 +42,7 @@ class BNF:
                                             fixed_delta=self.delta,
                                             d0=self.d0,
                                             demean=self.demean,
-                                            adjust_bands=self.adjust_bands,
+                                            adjusted_bands=self.adjust_bands,
                                             outliers=self.outliers_for_se,
                                             dynamic_bands=self.dynamic_bands,
                                             ib=self.ib,


### PR DESCRIPTION
Changes in this PR:

- `adjust_bands` was renamed to `adjusted_bands`. This was because the return value of `bnf` will always contain the standard bands without adjustment and if `adjusted_bands = true` also the adjusted bands.
- The computing of the standard errors has been extracted to its own function. This also allows for two nice optimisations, which saves a fair bit of overhead.  Now, the standard errors are only ever computed once when calling `bnf`. Prior to that is was being computed on ever iteration of `idm` which is unnecessary and reduces the strain on our small server instance.
- If `adjusted_bands = true` the plot will have a blue overlay to see the CI delta between adjusted and unadjusted bands.


Note that in a previous PR: 
- `dummies` was renamed to `outliers`
- The accompanying Python code was updated to call the `bnf` API.